### PR TITLE
fix: Update Card component to show a short URL and update copy function

### DIFF
--- a/src/app/_components/Card/Card.tsx
+++ b/src/app/_components/Card/Card.tsx
@@ -51,7 +51,7 @@ export default function Card({ slug, description, id }: LinkProps) {
       const copyLinkElement = document.getElementById(`copyLink${id}`);
       const textToCopy = copyLinkElement?.textContent ?? '';
 
-      await navigator.clipboard.writeText(textToCopy);
+      await navigator.clipboard.writeText(`${slugLinkURL + textToCopy}`);
     } catch (err) {
       errorToastHandler({ message: 'Failed to copy link to clipboard!' });
     } finally {
@@ -61,7 +61,7 @@ export default function Card({ slug, description, id }: LinkProps) {
 
   return (
     <section className="inline-block space-y-2 border border-white/10 bg-dark-midnight rounded-md relative px-4 py-2 w-full">
-      <p id={`copyLink${id}`}>{`${slugLinkURL}/${slug}`}</p>
+      <p id={`copyLink${id}`}>{`/${slug}`}</p>
       <div className="flex justify-between">
         <p className="text-sm font-thin">{description}</p>
       </div>


### PR DESCRIPTION
## Fixes Issue

close #10

## Changes Proposed
Update link cards to show only the slug for the URL and not the entire URL 

## Checklist (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

![image](https://github.com/HpatricioH/SlugLink/assets/59483053/1c0de885-272b-451c-8522-192ebd3c826a)

