### PR TITLE
feat: Add random slug generation feature in CreateLink component

### DIFF
--- a/src/app/_components/CreateLink/CreateLink.tsx
+++ b/src/app/_components/CreateLink/CreateLink.tsx
@@ -14,25 +14,28 @@ interface CreateLinkProps {
 export default function CreateLink(props: CreateLinkProps) {
   const [urlError, setUrlError] = useState(false)
   const [slugError, setSlugError] = useState(false)
-  const [randomSlug, setRandomSlug] = useState("")
   const [slug, setSlug] = useState('');
   const ref = useRef<HTMLFormElement>(null)
   const router = useRouter()
 
   const createLink = api.link.create.useMutation()
 
-  const randomizeSlug = async (e: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
-    e.preventDefault()
+  const generateRandomSlug = (): string => {
     const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
     let result = ''
     const length = 5
     for (let i = 0; i < length; i++) {
       result += characters.charAt(Math.floor(Math.random() * characters.length))
     }
-    setRandomSlug(result)
+    return result
   }
 
-  console.log(randomSlug)
+  const randomizeSlug = async (e: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
+    e.preventDefault()
+    const newSlug = generateRandomSlug()
+    setSlug(newSlug)
+  }
+
   async function onSubmit(event: FormEvent<HTMLFormElement>, ref: React.RefObject<HTMLFormElement>) {
     event.preventDefault()
     const formData = new FormData(event.currentTarget)
@@ -97,12 +100,13 @@ export default function CreateLink(props: CreateLinkProps) {
               name='slug'
               placeholder={`myLink`}
               className={`input input-block ${slugError ? 'input-error' : ''}`}
-              defaultValue={randomSlug}
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
               onFocus={() => setSlugError(false)} />
             <Button
               className="absolute right-0"
               type="button"
-              onClick={(e: React.MouseEvent<HTMLButtonElement>) => randomizeSlug(e)}>
+              onClick={randomizeSlug}>
               Randomize
             </Button>
           </div>

--- a/src/app/_components/CreateLink/CreateLink.tsx
+++ b/src/app/_components/CreateLink/CreateLink.tsx
@@ -14,11 +14,25 @@ interface CreateLinkProps {
 export default function CreateLink(props: CreateLinkProps) {
   const [urlError, setUrlError] = useState(false)
   const [slugError, setSlugError] = useState(false)
+  const [randomSlug, setRandomSlug] = useState("")
+  const [slug, setSlug] = useState('');
   const ref = useRef<HTMLFormElement>(null)
   const router = useRouter()
 
   const createLink = api.link.create.useMutation()
 
+  const randomizeSlug = async (e: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
+    e.preventDefault()
+    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+    let result = ''
+    const length = 5
+    for (let i = 0; i < length; i++) {
+      result += characters.charAt(Math.floor(Math.random() * characters.length))
+    }
+    setRandomSlug(result)
+  }
+
+  console.log(randomSlug)
   async function onSubmit(event: FormEvent<HTMLFormElement>, ref: React.RefObject<HTMLFormElement>) {
     event.preventDefault()
     const formData = new FormData(event.currentTarget)
@@ -77,12 +91,21 @@ export default function CreateLink(props: CreateLinkProps) {
         </div>
         <div className="form-field mt-1">
           <label className="form-label">Customize your link:</label>
-          <input
-            type="text"
-            name='slug'
-            placeholder={`myLink`}
-            className={`input input-block ${slugError ? 'input-error' : ''}`}
-            onFocus={() => setSlugError(false)} />
+          <div className="flex relative">
+            <input
+              type="text"
+              name='slug'
+              placeholder={`myLink`}
+              className={`input input-block ${slugError ? 'input-error' : ''}`}
+              defaultValue={randomSlug}
+              onFocus={() => setSlugError(false)} />
+            <Button
+              className="absolute right-0"
+              type="button"
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => randomizeSlug(e)}>
+              Randomize
+            </Button>
+          </div>
         </div>
         <div className="form-field mt-1">
           <label className="form-label">Description (Optional):</label>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. Replace #999 with the issue number you are fixing -->

## Fixes Issue

closes #20 

## Changes Proposed

Added a button and a function to randomize the slug for the link 

<!-- Mark all the applicable boxes. To mark the box as done, follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Checklist (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

![image](https://github.com/user-attachments/assets/7ec35bfd-0613-420e-99e9-2f60c1c8ec7a)
